### PR TITLE
Change bertha recipe to also require one artillery turret for crafting

### DIFF
--- a/bigger-artillery_VERSION/data/bertha.lua
+++ b/bigger-artillery_VERSION/data/bertha.lua
@@ -44,6 +44,11 @@ recipe.ingredients ={
     name = "low-density-structure", 
     amount = 50,
     type = "item"
+  },
+  {
+    name = "artillery-turret", 
+    amount = 1,
+    type = "item"
   }
 }
 recipe.results = {

--- a/bigger-artillery_VERSION/info.json
+++ b/bigger-artillery_VERSION/info.json
@@ -1,6 +1,6 @@
 {
   "name": "bigger-artillery",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "title": "Bigger Artillery",
   "author": "Mrxmen24",
   "factorio_version": "2.0",


### PR DESCRIPTION
As stated in the title, this changes the recipe to also incorporate a normal artillery turret. 
This way, the new materials from Space Exploration are also incorporated indirectly. (this may or may not take care of #2 )

The lowest version number has also been bumped, and the recipe does correctly load and show up ingame, so it should be good to go, i think.

![image](https://github.com/user-attachments/assets/4901eabc-9cf2-400d-ad9d-79287b22e4e9)
